### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ If you want to add this library to your game then import the [**unity-movement-a
 
 Feel free to only use what you need from the package.
 
-#Examples
+# Examples
 If you would like to play around with the library then download this whole repository and open it in Unity. The **Examples** folder holds a number of premade scenes for you to play around with.
 
-#Additional Info
+# Additional Info
 The library comes with the following steering behaviors:
 `Arrive`, `Cohesion`, `Collision Avoidance`, `Evade`, `Flee`, `Follow Path`, `Hide`, `Interpose`, `Offset Pursuit`, `Pursue`, `Seek`, `Separation`, `Velocity Match`, `Wall Avoidance`, and `Wander`.
 
 Most steering behaviors have their own file, but `Arrive`, `Interpose`, and `Seek` are all located within the **SteeringBasics.cs** file.
 
-#Previews
+# Previews
 Here are some previews of the different movement AI that come with this library.
 
 ### Arrive


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
